### PR TITLE
[PATCH] Fix some unit tests

### DIFF
--- a/tests/GitODBTest.php
+++ b/tests/GitODBTest.php
@@ -7,40 +7,37 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__ . "/lib/MemoryBackend.php";
+require_once __DIR__ . '/lib/MemcachedBackend.php';
+require_once __DIR__ . '/lib/MemoryBackend.php';
 
 class GitODBTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        // currentry nothing to do.
+        // currently nothing to do.
     }
 
     protected function tearDown()
     {
-        // currentry nothing to do.
+        // currently nothing to do.
     }
 
-    public function testCheckMemcachedModule()
-    {
-        $this->assertEquals(true,extension_loaded("memcached"));
-        require_once __DIR__ . "/lib/MemcachedBackend.php";
-    }
-
-    /**
-     * @depends testCheckMemcachedModule
-     */
     public function testConstruct()
     {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped('Requires extension memcached');
+        }
+
         $odb = new Git\ODB();
         $this->assertTrue($odb instanceof Git\ODB);
     }
 
-    /**
-     * @depends testCheckMemcachedModule
-     */
     public function testAddBackend()
     {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped('Requires extension memcached');
+        }
+
         $odb = new Git\ODB();
         $memcached = new Git\Backend\Memcached();
         $odb->addBackend($memcached,5);
@@ -49,7 +46,6 @@ class GitODBTest extends \PHPUnit_Framework_TestCase
 
     public function testMemoryBackend()
     {
-
         $odb = new Git\ODB();
         $memory = new Git\Backend\Memory();
         $odb->addBackend($memory,5);

--- a/tests/GitODBTest.php
+++ b/tests/GitODBTest.php
@@ -15,25 +15,25 @@ class GitODBTest extends \PHPUnit_Framework_TestCase
     {
         // currentry nothing to do.
     }
-    
+
     protected function tearDown()
     {
         // currentry nothing to do.
     }
-    
+
     public function testCheckMemcachedModule()
     {
         $this->assertEquals(true,extension_loaded("memcached"));
         require_once __DIR__ . "/lib/MemcachedBackend.php";
     }
-    
+
     /**
      * @depends testCheckMemcachedModule
      */
     public function testConstruct()
     {
         $odb = new Git\ODB();
-        $this->assertInstanceof("Git\\ODB",$odb);
+        $this->assertTrue($odb instanceof Git\ODB);
     }
 
     /**
@@ -44,7 +44,7 @@ class GitODBTest extends \PHPUnit_Framework_TestCase
         $odb = new Git\ODB();
         $memcached = new Git\Backend\Memcached();
         $odb->addBackend($memcached,5);
-        $this->assertInstanceof("Git\\ODB",$odb);
+        $this->assertTrue($odb instanceof Git\ODB);
     }
 
     public function testMemoryBackend()
@@ -53,15 +53,15 @@ class GitODBTest extends \PHPUnit_Framework_TestCase
         $odb = new Git\ODB();
         $memory = new Git\Backend\Memory();
         $odb->addBackend($memory,5);
-        $this->assertInstanceof("Git\\ODB",$odb);
+        $this->assertTrue($odb instanceof Git\ODB);
     }
-    
+
     public function testAddAlternate()
     {
 
         $odb = new Git\ODB();
         $memory = new Git\Backend\Memory();
         $odb->addAlternate($memory,5);
-        $this->assertInstanceof("Git\\ODB",$odb);
+        $this->assertTrue($odb instanceof Git\ODB);
     }
 }

--- a/tests/GitReferenceTest.php
+++ b/tests/GitReferenceTest.php
@@ -14,12 +14,12 @@ class GitReferenceTest extends \PHPUnit_Framework_TestCase
         //this test still legacy. fix environment probrem soon
         $this->markTestSkipped();
     }
-    
+
     protected function tearDown()
     {
         // currentry nothing to do.
     }
-    
+
     /**
      * Repository can lookup Git Reference.
      */
@@ -27,10 +27,10 @@ class GitReferenceTest extends \PHPUnit_Framework_TestCase
     {
         $rep = new Git\Repository(dirname(__DIR__) . "/.git/");
         $reference = $rep->lookupRef("refs/heads/develop");
-        $this->assertInstanceof("Git\\Reference",$reference,"returned object does not Git\\Reference");
+        $this->assertTrue($reference instanceof Git\Reference, 'returned object does not Git\\Reference');
     }
-    
-    
+
+
     /**
      * Reference can call getType()
      */
@@ -41,7 +41,7 @@ class GitReferenceTest extends \PHPUnit_Framework_TestCase
         $type = $ref->getType();
         $this->assertEquals(1,$type,"illegal reference type returned.(this is legacy test. check test file)");
     }
-    
+
     /**
      * Reference can call getName();
      */
@@ -50,10 +50,10 @@ class GitReferenceTest extends \PHPUnit_Framework_TestCase
         $rep = new Git\Repository(dirname(__DIR__) . "/.git/");
         $ref = $rep->lookupRef("refs/heads/develop");
         $name = $ref->getName();
-        
+
         $this->assertEquals("refs/heads/develop",$name,"reference name missmatched.");
     }
-    
+
     /**
      * Reference can call getId();
      */
@@ -62,7 +62,7 @@ class GitReferenceTest extends \PHPUnit_Framework_TestCase
         $rep = new Git\Repository(dirname(__DIR__) . "/.git/");
         $ref = $rep->lookupRef("refs/heads/develop");
         $id = $ref->getId();
-        
+
         $this->assertEquals(40,strlen($id),"illegal oid size returned");
     }
 

--- a/tests/GitRevwalkTest.php
+++ b/tests/GitRevwalkTest.php
@@ -29,25 +29,25 @@ class GitRevwalkTest extends \PHPUnit_Framework_TestCase
     {
         // currentry nothing to do.
     }
-    
+
     public function testGetWalker()
     {
         $git = new Git\Repository(".git");
         $walker = $git->getWalker();
-        $this->assertInstanceOf("Git\\Revwalk",$walker);
+        $this->assertTrue($walker instanceof Git\Revwalk);
         unset($git);
     }
-    
+
     public function testPush()
     {
         $git = new Git\Repository(".git");
         $walker = $git->getWalker();
         $walker->push("1def80657903dcf8d9d87a5e4edfaca92ddcff38");
         $commit = $walker->next();
-        $this->assertInstanceof("Git\\Commit",$commit);
+        $this->assertTrue($commit instanceof Git\Commit);
         unset($git);
     }
-    
+
     public function testRest()
     {
         $git = new Git\Repository(".git");
@@ -69,6 +69,6 @@ class GitRevwalkTest extends \PHPUnit_Framework_TestCase
         $walker = $git->getWalker();
         $walker->sort(Git\Revwalk\SORT_NONE);
         $walker->push("1def80657903dcf8d9d87a5e4edfaca92ddcff38");
-        $this->assertInstanceof("Git\\Commit",$walker->next());
+        $this->assertTrue($walker->next() instanceof Git\Commit);
     }
 }

--- a/tests/GitTest.php
+++ b/tests/GitTest.php
@@ -27,7 +27,7 @@ class GitTest extends \PHPUnit_Framework_TestCase
     {
         // currentry nothing to do.
     }
-    
+
     protected function tearDown()
     {
         // currentry nothing to do.
@@ -37,14 +37,14 @@ class GitTest extends \PHPUnit_Framework_TestCase
     {
         //this test still legacy. fix environment probrem soon
         $this->markTestSkipped();
-        
+
         //temporary added Git\\Reference.
         $git = new Git\Repository(dirname(__DIR__) . "/.git/");
         $ref = $git->lookupRef("refs/heads/master");
         $commit = $git->getCommit($ref->oid);
 
-        $this->assertInstanceof("Git\\Reference",$ref,"Git\\Referenceが帰ってきているか？");
-        $this->assertInstanceof("Git\\Commit",$commit,"Git\\Commitが帰ってきているか？");
+        $this->assertTrue($ref instanceof Git\Reference, 'Git\\Referenceが帰ってきているか？');
+        $this->assertTrue($commit instanceof Git\Commit, 'Git\\Commitが帰ってきているか？');
     }
 
 
@@ -59,27 +59,27 @@ class GitTest extends \PHPUnit_Framework_TestCase
     {
        $git = new Git\Repository(dirname(__DIR__) . "/.git/");
        $tree= $git->getTree("c40b970eb68bd1c8980f1f97b57396f4c7ae107f");
-       $this->assertInstanceof("Git\\Tree",$tree);
+       $this->assertTrue($tree instanceof Git\Tree);
        $this->assertEquals("c40b970eb68bd1c8980f1f97b57396f4c7ae107f",$tree->getId());
        foreach($tree->entries as $entry){
            $object = $entry->toObject();
-           $this->assertInstanceof("Git\\Object",$object);
-           if($object->getType() == GIT\Object\Blob){
-               $this->assertInstanceof("Git\\Blob",$object);
-           }else if($object->getType() == GIT\Object\Tree) {
-               $this->assertInstanceof("Git\\Tree",$object);
-           }else {
-               $this->fail("unhandled object found.");
+           $this->assertTrue($object instanceof Git\Object);
+           if ($object->getType() == GIT\Object\Blob) {
+               $this->assertTrue($object instanceof Git\Blob);
+           } else if ($object->getType() == GIT\Object\Tree) {
+               $this->assertTrue($object instanceof Git\Tree);
+           } else {
+               $this->fail('unhandled object found.');
            }
        }
     }
-    
+
     public function testRepositoryInit()
     {
         $this->rmdir(__DIR__ . "/init_sample");
         $repo = Git\Repository::init(__DIR__ . "/init_sample",1);
         $this->assertTrue(file_exists(__DIR__ . "/init_sample"));
-        $this->assertInstanceof("Git\\Repository",$repo);
+        $this->assertTrue($repo instanceof Git\Repository);
         $this->rmdir(__DIR__ . "/init_sample");
     }
 
@@ -88,7 +88,7 @@ class GitTest extends \PHPUnit_Framework_TestCase
 
         try{
             $git = new Git\Repository(dirname(__DIR__) . "/.git/");
-            $this->assertInstanceof("Git\\Repository",$git);
+            $this->assertTrue($git instanceof Git\Repository);
             unset($git);
         }catch(\Exception $e){
             $this->fail();
@@ -96,26 +96,26 @@ class GitTest extends \PHPUnit_Framework_TestCase
 
         try{
             $git = new Git\Repository("./.git");
-            $this->assertInstanceof("Git\\Repository",$git,"Git\\Repository::__construct allowed null parameter. refs #127");
+            $this->assertTrue($git instanceof Git\Repository, 'Git\\Repository::__construct allowed null parameter. refs #127');
         }catch(\Exception $e){
             $this->fail();
         }
     }
-    
+
     public function testGetIndex()
     {
         $git = new Git\Repository(dirname(__DIR__) . "/.git/");
         $index = $git->getIndex();
-        if($index instanceof Git\Index){
-            foreach($index as $entry){
-                $this->assertInstanceof("Git\\Index\\Entry",$entry);
+        if ($index instanceof Git\Index) {
+            foreach($index as $entry) {
+                $this->assertTrue($entry instanceof Git\Index\Entry);
             }
             return true;
-        }else{
-            return false;
         }
+
+        return false;
     }
-    
+
     public function testInitRepository()
     {
         require_once __DIR__ . "/lib/MemoryBackend.php";
@@ -124,8 +124,8 @@ class GitTest extends \PHPUnit_Framework_TestCase
 
         $this->rmdir(__DIR__ . "/git_init_test");
         mkdir(__DIR__ . "/git_init_test",0755);
-        
-    
+
+
         $backend = new Git\Backend\Memory();
         $repository = Git\Repository::init(__DIR__ . "/git_init_test",true);
         $repository->addBackend($backend,1);
@@ -133,24 +133,24 @@ class GitTest extends \PHPUnit_Framework_TestCase
         $blob = new Git\Blob($repository);
         $blob->setContent("First Object1");
         $hash = $blob->write();
-        
+
         $this->assertEquals("abd5864efb91d0fae3385e078cd77bf7c6bea826", $hash,"First Object1 write correctly");
         $this->assertEquals("abd5864efb91d0fae3385e078cd77bf7c6bea826", $blob->getid(),"rawobject and blob hash are same.");
         $data = $backend->read($hash);
         if($backend->read($hash)){
             $this->assertEquals("abd5864efb91d0fae3385e078cd77bf7c6bea826", $backend->read($hash)->getId(),"Backend return same rawobject");
         }
-        
+
         $tree = new Git\Tree($repository);
         $tree->add($hash,"README",100644);
         $tree_hash = $tree->write();
         $this->assertEquals("3c7493d000f58ae3eed94b0a3bc77d60694d33b4",$tree_hash, "tree writing");
-        
+
         $data = $backend->read("3c7493d000f58ae3eed94b0a3bc77d60694d33b4");
         if($data){
         $this->assertEquals("3c7493d000f58ae3eed94b0a3bc77d60694d33b4",$data->getId(), "Backend return same tree raw");
         }
-        
+
         $commit = new Git\Commit($repository);
         $commit->setAuthor(new Git\Signature("Someone","someone@example.com", new DateTime("2011-01-01 00:00:00",new DateTimezone("Asia/Tokyo"))));
         $commit->setCommitter(new Git\Signature("Someone","someone@example.com", new DateTime("2011-01-01 00:00:00",new DateTimezone("Asia/Tokyo"))));
@@ -158,7 +158,7 @@ class GitTest extends \PHPUnit_Framework_TestCase
         // when first commit. you dont call setParent.
         //$commit->setParent(""); 
         $commit->setMessage("initial import");
-        
+
         $master_hash = $commit->write();
 
         //$this->markTestIncomplete("this test does not implemente yet.");
@@ -174,7 +174,7 @@ class GitTest extends \PHPUnit_Framework_TestCase
 
         $this->rmdir(__DIR__ . "/git_init_test");
     }
-    
+
     protected function rmdir($dir)
     {
        if (is_dir($dir)) { 

--- a/tests/GitTreeTest.php
+++ b/tests/GitTreeTest.php
@@ -13,12 +13,12 @@
      {
          // currentry nothing to do.
      }
-     
+
      protected function tearDown()
      {
          // currentry nothing to do.
      }
-     
+
      public function testConstruct()
      {
          try{
@@ -48,10 +48,10 @@
             $repository = new Git\Repository("./.git");
             $tree = $repository->getTree("f031269837fabfa2c63e7a37b000a91171855f3f");
             $object = $tree->path("EXPERIMENTAL");
-            $this->assertInstanceof("Git\\Blob",$object,"正しくblobが取れている");
+            $this->assertTrue($object instanceof Git\Blob,'正しくblobが取れている');
             $this->assertEquals("80afdcd19e73e8e39757ebcdebedbf8fee2ebfc1",$object->getId());
             $object = $tree->path("docs");
-            $this->assertInstanceof("Git\\Tree",$object,"正しくtreeが取れている");
+            $this->assertTrue($object instanceof Git\Tree,"正しくtreeが取れている");
          }catch(\Exception $e){
              $this->fail();
          }

--- a/tests/lib/MemcachedBackend.php
+++ b/tests/lib/MemcachedBackend.php
@@ -10,7 +10,7 @@ namespace Git\Backend;
 class Memcached extends \Git\Backend
 {
     protected $memcached;
-    
+
     protected function serialize($value){
         return serialize($value);
     }
@@ -56,7 +56,7 @@ class Memcached extends \Git\Backend
            $raw->data = $data->data;
            $raw->type = $data->type;
        }
-       
+
        return $raw;
     }
 
@@ -74,7 +74,7 @@ class Memcached extends \Git\Backend
            $raw->data = null;
            $raw->type = $data->type;
        }
-       
+
        return $raw;
     }
 


### PR DESCRIPTION
The first patch fixes an issue about a not existing assert function.

The second patch uses markTestSkipped instead of relying on a test case to skip tests.
