### PR TITLE
[PATCH] Do not throw an error if extension memcached is missing

### DIFF
--- a/tests/GitODBTest.php
+++ b/tests/GitODBTest.php
@@ -7,61 +7,56 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__ . "/lib/MemoryBackend.php";
+require_once __DIR__ . '/lib/MemcachedBackend.php';
+require_once __DIR__ . '/lib/MemoryBackend.php';
 
 class GitODBTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        // currentry nothing to do.
-    }
-    
-    protected function tearDown()
-    {
-        // currentry nothing to do.
-    }
-    
-    public function testCheckMemcachedModule()
-    {
-        $this->assertEquals(true,extension_loaded("memcached"));
-        require_once __DIR__ . "/lib/MemcachedBackend.php";
-    }
-    
-    /**
-     * @depends testCheckMemcachedModule
-     */
-    public function testConstruct()
-    {
-        $odb = new Git\ODB();
-        $this->assertInstanceof("Git\\ODB",$odb);
+        // currently nothing to do.
     }
 
-    /**
-     * @depends testCheckMemcachedModule
-     */
+    protected function tearDown()
+    {
+        // currently nothing to do.
+    }
+
+    public function testConstruct()
+    {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped('Requires extension memcached');
+        }
+
+        $odb = new Git\ODB();
+        $this->assertInstanceof('Git\\ODB', $odb);
+    }
+
     public function testAddBackend()
     {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped('Requires extension memcached');
+        }
+
         $odb = new Git\ODB();
         $memcached = new Git\Backend\Memcached();
-        $odb->addBackend($memcached,5);
-        $this->assertInstanceof("Git\\ODB",$odb);
+        $odb->addBackend($memcached, 5);
+        $this->assertInstanceof('Git\\ODB', $odb);
     }
 
     public function testMemoryBackend()
     {
-
         $odb = new Git\ODB();
         $memory = new Git\Backend\Memory();
-        $odb->addBackend($memory,5);
-        $this->assertInstanceof("Git\\ODB",$odb);
+        $odb->addBackend($memory, 5);
+        $this->assertInstanceof('Git\\ODB', $odb);
     }
-    
+
     public function testAddAlternate()
     {
-
         $odb = new Git\ODB();
         $memory = new Git\Backend\Memory();
-        $odb->addAlternate($memory,5);
-        $this->assertInstanceof("Git\\ODB",$odb);
+        $odb->addAlternate($memory, 5);
+        $this->assertInstanceof('Git\\ODB', $odb);
     }
 }


### PR DESCRIPTION
Refactor the testcases a bit so we no longer use a testcase that only tests if the extension memcached is loaded. Depending testcases are now using  markTestSkipped, so these tests are still skipped when the extension is missing.
