### PR TITLE
Convert getParent error into exception for easier catching

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -359,7 +359,7 @@ PHP_METHOD(git_commit, getParent)
     
     ret = git_commit_parent(&commit, this->object,offset);
     if(ret != GIT_SUCCESS){
-        php_error_docref(NULL TSRMLS_CC, E_ERROR, "specified offset not found.");
+        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "specified offset not found");
         RETURN_FALSE;
     }
 


### PR DESCRIPTION
Convert getParent error into exception for easier catching (as this is not a fatal error really)

This makes it easier to do a loop through getParent.

For example, previously this would break:

``` php
$commit = $repo->getCommit($ref->getId());
for($i = 0; $i <= $limit; $i++)
{
  echo $commit->getId . "<br />";
  $commit = $commit->getParent(); // No way of stopping error - will fatal error when it reaches last commit
}
```

The error I get is:

```
Fatal error: Git\Commit::getParent(): specified offset not found. in /home/james/Dropbox/Eclipse Workspace/php-git-sample/index.php on line 123

Call Stack:
    0.0018     400244   1. {main}() /home/james/Dropbox/Eclipse Workspace/php-git-sample/index.php:0
    0.0147     785312   2. Silex\Application->run() /home/james/Dropbox/Eclipse Workspace/php-git-sample/index.php:183
    0.0197    1238872   3. Silex\Application->handle() phar:///home/james/Dropbox/Eclipse Workspace/php-git-sample/silex.phar/src/Silex/Application.php:144
    0.0220    1385380   4. Symfony\Component\HttpKernel\HttpKernel->handle() phar:///home/james/Dropbox/Eclipse Workspace/php-git-sample/silex.phar/src/Silex/Application.php:148
    0.0220    1385380   5. Symfony\Component\HttpKernel\HttpKernel->handleRaw() phar:///home/james/Dropbox/Eclipse Workspace/php-git-sample/silex.phar/vendor/Symfony/Component/HttpKernel/HttpKernel.php:25
    0.0283    1585404   6. call_user_func_array() phar:///home/james/Dropbox/Eclipse Workspace/php-git-sample/silex.phar/vendor/Symfony/Component/HttpKernel/HttpKernel.php:47
    0.0283    1585656   7. {closure}() phar:///home/james/Dropbox/Eclipse Workspace/php-git-sample/silex.phar/vendor/Symfony/Component/HttpKernel/HttpKernel.php:0
    0.0366    1600300   8. Git\Commit->getParent() /home/james/Dropbox/Eclipse Workspace/php-git-sample/index.php:123
```

However changing to an Exception will allow this to work:

``` php
$commit = $repo->getCommit($ref->getId());
for($i = 0; $i <= $limit; $i++)
{
  echo $commit->getId . "<br />";
  try {
    $commit = $commit->getParent();
  }
  catch(Exception $e) {
    echo "No more commits.";
    break;
  }
}
```

Hope that makes sense!
