### PR TITLE
Fixed compile error against latest libgit2 (2011-09-25)

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -296,6 +296,7 @@ PHP_METHOD(git_commit, write)
         update_ref,
         author->signature,
         committer->signature,
+		NULL, // Message encoding (Should probably fix this at some point)
         message,
         &tree_oid,
         count,


### PR DESCRIPTION
Fixed compile error against latest libgit2 for git_commit_create() missing message encoding.
