### PR TITLE
fixed minor typo in the libgit2 make instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd libgit2
 mkdir build
 cd build
 cmake ..
-cmake --build
+cmake --build .
 sudo cmake --build . --target install
 ````
 


### PR DESCRIPTION
hi. i just took a minute to fix a typo in the build instructions for libgit2. cmake needs the path in order to build the makefiles. the dot for the current path was missing in the first cmake --build command.
