### PR TITLE
Updated libgit2 gitmodule scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libgit2"]
 	path = libgit2
-	url = git@github.com:libgit2/libgit2.git
+	url = https://github.com/libgit2/libgit2.git


### PR DESCRIPTION
I updated libgit2 gitmodule scheme from `git` to `https`, because it won't work if you haven't sent your public key to Github.
