### PR TITLE
Add missing part in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ you need to install libgit2 before make php-git.
 
 ````
 git clone https://github.com/libgit2/php-git.git --recursive
-cd libgit2
+cd php-git/libgit2
 mkdir build && cd build
 cmake ..
 cmake -DBUILD_SHARED_LIBS=OFF -build .


### PR DESCRIPTION
Git clone creates a directory named after the project you are cloning. The initial step to change directory assumed we were already in the cloned directory, which would not be the case if you had just run the command above it.
