### PR TITLE
Crash in git_transport_register

### DIFF
--- a/helper.h
+++ b/helper.h
@@ -49,6 +49,8 @@ int php_git2_call_function_v(
 
 int php_git2_cb_init(php_git2_cb_t **out, zend_fcall_info *fci, zend_fcall_info_cache *fcc, void *payload TSRMLS_DC);
 
+int php_git2_cb_init_copy(php_git2_cb_t **out, zend_fcall_info *fci, zend_fcall_info_cache *fcc, void *payload TSRMLS_DC);
+
 void php_git2_cb_free(php_git2_cb_t *target);
 
 void php_git2_array_to_strarray(git_strarray *out, zval *array TSRMLS_DC);

--- a/php_git2.h
+++ b/php_git2.h
@@ -203,6 +203,7 @@ typedef struct php_git2_cb_t {
 	zval *payload;
 	zend_fcall_info *fci;
 	zend_fcall_info_cache *fcc;
+	int is_copy;
 	GIT2_TSRMLS_DECL
 } php_git2_cb_t;
 

--- a/transport.c
+++ b/transport.c
@@ -77,7 +77,6 @@ PHP_FUNCTION(git_transport_register)
 		RETURN_FALSE;
 	}
 	result = git_transport_register(prefix, priority, php_git2_transport_cb, cb);
-	php_git2_cb_free(cb);
 	RETURN_LONG(result);
 }
 /* }}} */

--- a/transport.c
+++ b/transport.c
@@ -73,7 +73,7 @@ PHP_FUNCTION(git_transport_register)
 		return;
 	}
 
-	if (php_git2_cb_init(&cb, &fci, &fcc, param TSRMLS_CC)) {
+	if (php_git2_cb_init_copy(&cb, &fci, &fcc, param TSRMLS_CC)) {
 		RETURN_FALSE;
 	}
 	result = git_transport_register(prefix, priority, php_git2_transport_cb, cb);


### PR DESCRIPTION
git_transport_register will register a callback, then free said callback before returning, resulting in a crash when said callback is to be used.

This patch removes the call to php_git2_cb_free(), and also implements a new helper php_git2_cb_init_copy() that will duplicate fci/fcc (to be freed in php_git2_cb_free if needed).

Ideally we should also free the callback in the unregister method - but considering most transports are likely to survive until the end of execution of the script that might have a lower priority.
